### PR TITLE
Support ID definition inside embedded struct

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -58,6 +58,10 @@ func Compare(ctx context.Context, old, new interface{}) ([]Diff, error) {
 			}
 
 			if len(nestedDiffs) > 0 {
+				if objectID == "" && nestedDiffs[0].ObjectID != "" {
+					objectID = nestedDiffs[0].ObjectID
+				}
+
 				diffs = append(diffs, nestedDiffs...)
 				continue
 			}


### PR DESCRIPTION
There is a case when the Object ID tag is defined inside of the Embedded struct e.g. id in the base entity object. To support this case, I check whether the object ID of nested diffs is available or not. It will be still checked if the ID tag is defined in both the main and embedded struct.