### PR TITLE
Support hidden struct with String function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ for i, diff := range diffs {
 
 Please see [examples](https://pkg.go.dev/github.com/haritsfahreza/libra#ex-Compare--Struct) for the other usage references
 
+### Comparing struct with private fields
+
+Currently, we need to have `String` function to get the value of the struct with private fields since `reflect` library would not be able to compare them.
+
+```go
+type HiddenPerson struct {
+	name string
+	age int
+}
+
+func (h HiddenPerson) String() string {
+	return fmt.Sprintf("%s, %d", h.name, h.age)
+}
+```
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](https://github.com/haritsfahreza/libra/blob/master/CODE_OF_CONDUCT.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/pkg/comparator/comparator.go
+++ b/pkg/comparator/comparator.go
@@ -50,9 +50,13 @@ func isNestedKind(kind reflect.Kind) bool {
 		kind == reflect.Func
 }
 
-func getInterfaceValue(v reflect.Value) reflect.Value {
+func filterValue(v reflect.Value) reflect.Value {
 	if v.Kind() == reflect.Interface {
 		return reflect.ValueOf(v.Interface())
+	}
+
+	if m := v.MethodByName("String"); m.IsValid() {
+		return m.Call([]reflect.Value{})[0]
 	}
 
 	return v

--- a/pkg/comparator/map.go
+++ b/pkg/comparator/map.go
@@ -24,8 +24,8 @@ func (c *MapComparator) Compare(ctx context.Context, oldVal, newVal reflect.Valu
 			return nil, fmt.Errorf("Error on validate key %s Error : %s", key.String(), err.Error())
 		}
 
-		filteredOldValue := getInterfaceValue(oldField)
-		filteredNewValue := getInterfaceValue(newField)
+		filteredOldValue := filterValue(oldField)
+		filteredNewValue := filterValue(newField)
 		if isNestedKind(filteredOldValue.Kind()) {
 			nestedDiffs, err := compareNestedField(
 				ctx,

--- a/pkg/comparator/struct.go
+++ b/pkg/comparator/struct.go
@@ -29,8 +29,8 @@ func (c *StructComparator) Compare(ctx context.Context, oldVal, newVal reflect.V
 			return nil, fmt.Errorf("Error on validate key %s Error : %s", typeField.Name, err.Error())
 		}
 
-		filteredOldValue := getInterfaceValue(oldField)
-		filteredNewValue := getInterfaceValue(newField)
+		filteredOldValue := filterValue(oldField)
+		filteredNewValue := filterValue(newField)
 		if isNestedKind(filteredOldValue.Kind()) {
 			nestedDiffs, err := compareNestedField(
 				ctx,

--- a/test/comparator/struct_test.go
+++ b/test/comparator/struct_test.go
@@ -4,22 +4,24 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/haritsfahreza/libra/pkg/comparator"
 	"github.com/haritsfahreza/libra/pkg/diff"
 )
 
 type person struct {
-	ID        int `libra:"id"`
-	Name      string
-	Age       int
-	Weight    float64
-	IsMarried bool
-	Hobbies   []string
-	Numbers   []int
-	Ignore    string `libra:"ignore"`
-	Interface interface{}
-	Address   address
+	ID          int `libra:"id"`
+	Name        string
+	Age         int
+	Weight      float64
+	IsMarried   bool
+	Hobbies     []string
+	Numbers     []int
+	Ignore      string `libra:"ignore"`
+	Interface   interface{}
+	Address     address
+	DateOfBirth time.Time
 }
 
 type address struct {
@@ -80,14 +82,16 @@ func TestStructComparator_Compare(t *testing.T) {
 			args{
 				ctx: nil,
 				old: person{
-					ID:      10,
-					Name:    "test1",
-					Numbers: []int{1, 2, 3},
+					ID:          10,
+					Name:        "test1",
+					Numbers:     []int{1, 2, 3},
+					DateOfBirth: time.Date(2020, time.May, 4, 0, 0, 0, 0, time.UTC),
 				},
 				new: person{
-					ID:      10,
-					Name:    "test2",
-					Numbers: []int{1, 2, 4},
+					ID:          10,
+					Name:        "test2",
+					Numbers:     []int{1, 2, 4},
+					DateOfBirth: time.Date(2020, time.May, 30, 0, 0, 0, 0, time.UTC),
 				},
 			},
 			[]diff.Diff{{
@@ -104,6 +108,13 @@ func TestStructComparator_Compare(t *testing.T) {
 				ObjectID:   "10",
 				Old:        "1,2,3",
 				New:        "1,2,4",
+			}, {
+				ChangeType: diff.Changed,
+				ObjectType: "comparator_test.person",
+				Field:      "DateOfBirth",
+				ObjectID:   "10",
+				Old:        "2020-05-04 00:00:00 +0000 UTC",
+				New:        "2020-05-30 00:00:00 +0000 UTC",
 			}},
 			false,
 		}, {


### PR DESCRIPTION
There is a need to compare struct that has a private field e.g. `time.Time`. Start with this idea, I decide to compare the `String` function if the struct has an unexported field.