### PR TITLE
Ignore unexported struct field

### DIFF
--- a/pkg/comparator/struct.go
+++ b/pkg/comparator/struct.go
@@ -20,6 +20,10 @@ func (c *StructComparator) Compare(ctx context.Context, oldVal, newVal reflect.V
 		oldField := oldVal.Field(i)
 		newField := newVal.Field(i)
 
+		if !typeField.IsExported() {
+			continue
+		}
+
 		tag := typeField.Tag.Get("libra")
 		if tag == "ignore" || tag == "id" {
 			continue

--- a/pkg/comparator/struct_test.go
+++ b/pkg/comparator/struct_test.go
@@ -47,6 +47,12 @@ type anotherPerson struct {
 	Name    string
 }
 
+type structWithPrivateField struct {
+	ID         int `libra:"id"`
+	Name       string
+	secretName string
+}
+
 func TestStructComparator_Compare(t *testing.T) {
 	oldEmbeddedAddress := embeddedAddress{}
 	oldEmbeddedAddress.ID = 10
@@ -261,6 +267,28 @@ func TestStructComparator_Compare(t *testing.T) {
 				ObjectID:   "10",
 				Old:        "Jalan 123",
 				New:        "Jalan ABC",
+			}},
+			false,
+		}, {
+			"succeed when compare struct with private field",
+			args{
+				ctx: nil,
+				old: structWithPrivateField{
+					ID:   10,
+					Name: "test1",
+				},
+				new: structWithPrivateField{
+					ID:   10,
+					Name: "test2",
+				},
+			},
+			[]diff.Diff{{
+				ChangeType: diff.Changed,
+				ObjectType: "comparator_test.structWithPrivateField",
+				Field:      "Name",
+				ObjectID:   "10",
+				Old:        "test1",
+				New:        "test2",
 			}},
 			false,
 		},


### PR DESCRIPTION
There is an error when users compare structs with unexported fields inside, although it's not being used. To fix the issue, I ignore unexported fields when comparing the struct. This will solve issue #18 